### PR TITLE
ツール検索を押した際に「AmbiguousMatchException」が出るバグを修正

### DIFF
--- a/Editor/ToolSelectDropdown.cs
+++ b/Editor/ToolSelectDropdown.cs
@@ -54,11 +54,14 @@ namespace ToolLauncher
                          .SelectMany(x =>
                              x.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)))
             {
-                var menuItem = methodInfo.GetCustomAttribute<MenuItem>();
-                if (menuItem == null) continue;
-                if (menuItem.menuItem.StartsWith("CONTEXT")) continue;
+                var menuItems = methodInfo.GetCustomAttributes<MenuItem>();
+                foreach (var menuItem in menuItems)
+                {
+                    if (menuItem == null) continue;
+                    if (menuItem.menuItem.StartsWith("CONTEXT")) continue;
 
-                result.Add((menuItem.menuItem, methodInfo));
+                    result.Add((menuItem.menuItem, methodInfo));
+                }
             }
 
             _menuItemMethodsCache = result;


### PR DESCRIPTION
# 概要
ToolLauncherSettingの「ツール検索」を押した際に、
AmbiguousMatchExceptionが出るバグを修正いたしました。

# 環境
Unity2022.3.5f1
Universal RP 14.0.8

**Built-in環境ではバグは確認できませんでした。**

# 原因
URPでは複数のMenuItemを持つメソッドがあり、
そのせいで、GetCustomAttribute()時にAmbiguousMatchExceptionが出ていたようです。

# 対応
GetCustomAttribute() ではなく、
GetCustomAttribute**s**()を呼ぶように変更いたしました。