### PR TITLE
MenuCommandを引数に持つメソッドに対応

### DIFF
--- a/Editor/ListDrawer/RectangleListDrawer.cs
+++ b/Editor/ListDrawer/RectangleListDrawer.cs
@@ -119,7 +119,7 @@ namespace ToolLauncher.ListDrawer
                 else if (originalRect.Contains(current.mousePosition))
                 {
                     var serializedMethodInfo = SerializedMethodInfo.DeserializeFromJson(menu.serializedMethodInfoStr);
-                    serializedMethodInfo?.Method?.Invoke(null, null);
+                    serializedMethodInfo?.Invoke();
                 }
 
                 current.Use();

--- a/Editor/SerializedMethodInfo.cs
+++ b/Editor/SerializedMethodInfo.cs
@@ -37,6 +37,17 @@ namespace ToolLauncher
             return json;
         }
 
+        public void Invoke()
+        {
+            var parameterInfos = Method?.GetParameters();
+            bool hasMenuCommandParam = parameterInfos?.Length == 1;
+            var parameters = hasMenuCommandParam
+                ? new object[] { new MenuCommand(default, default) }
+                : null;
+
+            Method?.Invoke(null, parameters);
+        }
+
         private SerializedMethodInfo(MethodInfo methodInfo)
         {
             _assemblyQualifiedName = methodInfo.ReflectedType?.AssemblyQualifiedName;

--- a/Editor/ToolLauncherSetting.cs
+++ b/Editor/ToolLauncherSetting.cs
@@ -121,7 +121,7 @@ namespace ToolLauncher
                 if (!string.IsNullOrEmpty(propMethodInfoStr.stringValue))
                 {
                     var serializedMethodInfo = SerializedMethodInfo.DeserializeFromJson(propMethodInfoStr.stringValue);
-                    serializedMethodInfo?.Method?.Invoke(null, null);
+                    serializedMethodInfo?.Invoke();
                 }
             }
         }


### PR DESCRIPTION
# 概要
PackageManagerWindowを登録し呼んだ際、
TargetParameterCountExceptionが出るため修正いたしました。

# 環境
Unity2022.3.5f1

# 原因
UnityEditor.PackageManager.UI.Window.**ShowPackageManagerWindow**()のシグネチャは、
```csharp
internal static void ShowPackageManagerWindow(MenuCommand item)
```
となっており仮引数を持ちます。

現状の書き方だと、Invokeの実引数が
```csharp
serializedMethodInfo?.Method?.Invoke(null, null);
```
となっているため[TargetParameterCountException](https://learn.microsoft.com/ja-jp/dotnet/api/system.reflection.targetparametercountexception?view=net-7.0)が投げられます。

# 対応
```csharp
var parameterInfos = Method?.GetParameters();
bool hasMenuCommandParam = parameterInfos?.Length == 1;
var parameters = hasMenuCommandParam
    ? new object[] { new MenuCommand(default, default) }
    : null;
Method?.Invoke(null, parameters);
```
メソッドの仮引数の数を確認し、
結果によってInvoke()に渡す実引数を分岐するようにいたしました。