### PR TITLE
タグ機能を追加します

### DIFF
--- a/Editor/ListDrawer/ListDrawerParam.cs
+++ b/Editor/ListDrawer/ListDrawerParam.cs
@@ -18,10 +18,16 @@ namespace ToolLauncher.ListDrawer
         /// </summary>
         public readonly int index;
 
-        public ListDrawerParam([NotNull] ToolLauncherSetting.ToolLauncherMenu menu, int index)
+        /// <summary>
+        /// タグ名
+        /// </summary>
+        public readonly TagData tagData;
+
+        public ListDrawerParam([NotNull] ToolLauncherSetting.ToolLauncherMenu menu, int index, TagData tagData = default)
         {
             this.menu = menu;
             this.index = index;
+            this.tagData = tagData;
         }
     }
 }

--- a/Editor/ListDrawer/ListDrawerParam.cs
+++ b/Editor/ListDrawer/ListDrawerParam.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using ToolLauncher.Tag;
 
 namespace ToolLauncher.ListDrawer
 {
@@ -19,7 +20,7 @@ namespace ToolLauncher.ListDrawer
         public readonly int index;
 
         /// <summary>
-        /// タグ名
+        /// タグ情報
         /// </summary>
         public readonly TagData tagData;
 

--- a/Editor/ListDrawer/RectangleListDrawer.cs
+++ b/Editor/ListDrawer/RectangleListDrawer.cs
@@ -54,6 +54,13 @@ namespace ToolLauncher.ListDrawer
                 textColor = Color.white,
             },
         };
+
+        public static readonly GUIStyle Tag = new GUIStyle(GUI.skin.GetStyle("sv_label_0"))
+        {
+            fixedWidth = 64,
+            fixedHeight = 16,
+            padding = new RectOffset(0, 0, 0, 2),
+        };
     }
 
     #endregion
@@ -70,6 +77,8 @@ namespace ToolLauncher.ListDrawer
             var originalRect = EditorGUILayout.GetControlRect(false, (EditorGUIUtility.singleLineHeight + 2f) * 2f);
             var current = Event.current;
             var hovered = originalRect.Contains(current.mousePosition);
+            var tagName = param.tagData.tagName;
+            var tagColor = param.tagData.tagColor;
 
             if (Event.current.type == EventType.Repaint)
             {
@@ -77,7 +86,7 @@ namespace ToolLauncher.ListDrawer
                 var bgStyle = index % 2 == 0 ? Styles.ItemBackground1 : Styles.ItemBackground2;
                 bgStyle.Draw(originalRect, hovered, false, false, false);
             }
-
+            
             // 左側のアイコン
             var iconStyle = Styles.TextIcon;
             // 文字数によって
@@ -85,6 +94,16 @@ namespace ToolLauncher.ListDrawer
                 iconStyle.fontSize = Mathf.Min(20, 40 / menu.iconText.Length);
             var imageRect = new Rect(originalRect) { width = Styles.TextIcon.fixedWidth };
             GUI.Label(imageRect, menu.iconText, Styles.TextIcon);
+
+            // タグカラー表示
+            if (!string.IsNullOrEmpty(param.tagData.tagName))
+            {
+                var color = GUI.color;
+                GUI.color = tagColor;
+                var iconRect = new Rect(originalRect) { width = 1 };
+                GUI.DrawTexture(iconRect, Texture2D.whiteTexture);
+                GUI.color = color;
+            }
 
             // 名前
             var nameLabelRect = new Rect(originalRect);

--- a/Editor/ListDrawer/RectangleListDrawer.cs
+++ b/Editor/ListDrawer/RectangleListDrawer.cs
@@ -96,7 +96,7 @@ namespace ToolLauncher.ListDrawer
             GUI.Label(imageRect, menu.iconText, Styles.TextIcon);
 
             // タグカラー表示
-            if (!string.IsNullOrEmpty(param.tagData.tagName))
+            if (!string.IsNullOrEmpty(tagName))
             {
                 var color = GUI.color;
                 GUI.color = tagColor;

--- a/Editor/Tag.meta
+++ b/Editor/Tag.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 24dfb1c7036d428ca6b12bc97f1c57be
+timeCreated: 1702092390

--- a/Editor/Tag/TagData.cs
+++ b/Editor/Tag/TagData.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace ToolLauncher
+{
+    public struct TagData
+    {
+        public string tagName;
+        public Color tagColor;
+
+        public TagData(string s, Color color)
+        {
+            tagName = s;
+            tagColor = color;
+        }
+    }
+}

--- a/Editor/Tag/TagData.cs
+++ b/Editor/Tag/TagData.cs
@@ -2,14 +2,24 @@ using UnityEngine;
 
 namespace ToolLauncher.Tag
 {
+    /// <summary>
+    /// ランチャー設定に付与するタグ情報
+    /// </summary>
     public struct TagData
     {
+        /// <summary>
+        /// タグの名前
+        /// </summary>
         public string tagName;
+        
+        /// <summary>
+        /// タグの色
+        /// </summary>
         public Color tagColor;
 
-        public TagData(string s, Color color)
+        public TagData(string tagName, Color color)
         {
-            tagName = s;
+            this.tagName = tagName;
             tagColor = color;
         }
     }

--- a/Editor/Tag/TagData.cs
+++ b/Editor/Tag/TagData.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace ToolLauncher
+namespace ToolLauncher.Tag
 {
     public struct TagData
     {

--- a/Editor/Tag/TagData.cs.meta
+++ b/Editor/Tag/TagData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 73084bb938564643990a436f652c5b62
+timeCreated: 1702105409

--- a/Editor/Tag/TagManager.cs
+++ b/Editor/Tag/TagManager.cs
@@ -7,15 +7,41 @@ using UnityEngine;
 namespace ToolLauncher.Tag
 {
     /// <summary>
-    /// タグ選択GUIの管理
+    /// タグの管理
     /// </summary>
     public class TagManager
     {
-        [NonSerialized] private Dictionary<string, bool> tagEnabled = new Dictionary<string, bool>();
+        /// <summary>
+        /// タグ有効状態
+        /// </summary>
+        private Dictionary<string, bool> tagEnabled = new Dictionary<string, bool>();
+        
+        /// <summary>
+        /// タグのテクスチャ
+        /// </summary>
         private Dictionary<string, Texture2D> tagTextures = new Dictionary<string, Texture2D>();
 
+        static class Options
+        {
+            /// <summary>
+            /// タグボタン先頭のラベル
+            /// </summary>
+            public static readonly GUILayoutOption[] TagHeaderLabel = new GUILayoutOption[]
+            {
+                GUILayout.Width(24),
+            };
+        }
+        
         static class Styles
         {
+            /// <summary>
+            /// タグボタン先頭のラベル
+            /// </summary>
+            public static readonly GUIStyle TagHeaderLabel = new GUIStyle(EditorStyles.label)
+            {
+                padding = new RectOffset(2, 0, 4, 0),
+            };
+            
             /// <summary>
             /// 有効なタグのボタン
             /// </summary>
@@ -114,12 +140,9 @@ namespace ToolLauncher.Tag
         
         public void OnGUI(ToolLauncherSetting[] settings)
         {
-            var box = new GUIStyle(GUI.skin.box);
-            box.wordWrap = true;
             using (new EditorGUILayout.HorizontalScope())
             {
-                GUILayout.Space(4);
-                EditorGUILayout.LabelField("タグ", GUILayout.Width(26));
+                EditorGUILayout.LabelField("タグ",　Styles.TagHeaderLabel, Options.TagHeaderLabel);
                 
                 foreach (var setting in settings)
                 {
@@ -171,11 +194,13 @@ namespace ToolLauncher.Tag
             
             // ボタンの中のアイコン
             var icon = GetIconTexture(setting.TagName, setting.TagColor);
-            var iconRect = new Rect(controlRect);
-            iconRect.x = controlRect.x + iconSize;
-            iconRect.y = controlRect.y + buttonStyle.fixedHeight / 2 - iconSize / 2;
-            iconRect.width = iconSize;
-            iconRect.height = iconSize;
+            var iconRect = new Rect(controlRect)
+            {
+                x = controlRect.x + iconSize,
+                y = controlRect.y + buttonStyle.fixedHeight / 2 - iconSize / 2,
+                width = iconSize,
+                height = iconSize
+            };
             GUI.DrawTexture(iconRect, icon);
 
             // 色を元に戻す

--- a/Editor/Tag/TagManager.cs
+++ b/Editor/Tag/TagManager.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace ToolLauncher
+{
+    /// <summary>
+    /// タグ選択GUIの管理
+    /// </summary>
+    public class TagManager
+    {
+        [NonSerialized] private Dictionary<string, bool> tagEnabled = new Dictionary<string, bool>();
+
+        private Dictionary<string, Texture2D> tagTextures = new Dictionary<string, Texture2D>();
+
+        static class Styles
+        {
+            public static readonly GUIStyle OnTagButton = new GUIStyle(GUI.skin.button)
+            {
+                margin = new RectOffset(0, 0, 3,  0),
+                padding = new RectOffset(8, 8, 0, 2),
+                fixedHeight = 20,
+                alignment = TextAnchor.MiddleRight,
+            };
+        
+            public static readonly GUIStyle OffTagButton = new GUIStyle(GUI.skin.button)
+            {
+                margin = new RectOffset(0, 0, 3,  0),
+                padding = new RectOffset(8, 8, 0, 2),
+                fixedHeight = 20,
+                alignment = TextAnchor.MiddleRight,
+            };
+        }
+
+        public int ActiveTagCount
+        {
+            get { return tagEnabled.Count(x => x.Value == true); }
+        }
+
+        /// <summary>
+        /// 指定のタグが有効か
+        /// </summary>
+        public bool IsTagActive(string tagName)
+        {
+            if (string.IsNullOrEmpty(tagName))
+            {
+                return false;
+            }
+            if (!tagEnabled.ContainsKey(tagName))
+            {
+                return false;
+            }
+            return tagEnabled[tagName];
+        }
+        
+        /// <summary>
+        /// 指定したタグのみ有効か
+        /// </summary>
+        public bool IsOnlyActive(string tagName)
+        {
+            if (string.IsNullOrEmpty(tagName))
+            {
+                return false;
+            }
+            if (!tagEnabled.ContainsKey(tagName))
+            {
+                return false;
+            }
+            if (!tagEnabled[tagName])
+            {
+                return false;
+            }
+
+            return ActiveTagCount == 1;
+        }
+
+        /// <summary>
+        /// タグの選択
+        /// </summary>
+        public void SelectTag(string tagName)
+        {
+            var keys = tagEnabled.Keys.ToArray();
+            foreach (var key in keys)
+            {
+                tagEnabled[key] = false;
+            }
+            SetTagActive(tagName, true);
+        }
+        
+        /// <summary>
+        /// タグの有効化
+        /// </summary>
+        public void SetTagActive(string tagName, bool active)
+        {
+            if (tagEnabled.ContainsKey(tagName))
+            {
+                tagEnabled[tagName] = active;
+            }
+            else
+            {
+                tagEnabled.Add(tagName, active);
+            }
+        }
+        
+        public void OnGUI(ToolLauncherSetting[] settings)
+        {
+            var box = new GUIStyle(GUI.skin.box);
+            box.wordWrap = true;
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUILayout.Space(4);
+                EditorGUILayout.LabelField("タグ", GUILayout.Width(26));
+                
+                var defaultColor = GUI.color;
+                var defaultBgColor = GUI.backgroundColor;
+                foreach (var setting in settings)
+                {
+                    var tag = setting.TagName;
+                    if (string.IsNullOrEmpty(tag))
+                    {
+                        continue;
+                    }
+
+                    if (!tagEnabled.ContainsKey(tag))
+                    {
+                        tagEnabled.Add(tag, false);
+                    }
+                    
+                    bool isOn = tagEnabled[tag];
+                    if (!isOn)
+                    {
+                        GUI.color = new Color(1, 1, 1, 0.5f);
+                    }
+                    else
+                    {
+                        GUI.color = defaultColor;
+                    }
+
+                    var style = isOn ? Styles.OnTagButton : Styles.OffTagButton;
+                    var icon = GetIconTexture(setting.TagName, setting.TagColor);
+                    GUIContent content = new GUIContent(tag);
+                    Vector2 contentSize = style.CalcSize(content);
+                    contentSize.x += 10;
+                    
+                    var controlRect = EditorGUILayout.GetControlRect(
+                        false, contentSize.y, style, 
+                        new GUILayoutOption[] { 
+                            GUILayout.Width(contentSize.x), 
+                            GUILayout.Height(contentSize.y)
+                        });
+                    
+                    bool isClick = GUI.Button(controlRect, content, style);
+                    var iconRect = new Rect(controlRect);
+                    const int iconSize = 6;
+                    iconRect.x = controlRect.x + iconSize;
+                    iconRect.y = controlRect.y + style.fixedHeight / 2 - iconSize / 2;
+                    iconRect.width = iconSize;
+                    iconRect.height = iconSize;
+                    GUI.DrawTexture(iconRect, icon);
+                    if (isClick)
+                    {
+                        tagEnabled[tag] = !isOn;
+                    }
+                }
+
+                GUI.backgroundColor = defaultBgColor;
+                GUI.color = defaultColor;
+                GUILayout.FlexibleSpace();
+            }
+        }
+
+        Texture2D GetIconTexture(string tag, Color c)
+        {
+            if (!tagTextures.ContainsKey(tag))
+            {
+                tagTextures[tag] = new Texture2D(1, 1);
+            }
+            
+            var t = tagTextures[tag];
+            for (int x = 0; x < t.width; x++)
+            {
+                for (int y = 0; y < t.height; y++)
+                {
+                    t.SetPixel(x, y, c);
+                }
+            }
+            t.Apply();
+            return t;
+        }
+    }
+}

--- a/Editor/Tag/TagManager.cs
+++ b/Editor/Tag/TagManager.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace ToolLauncher
+namespace ToolLauncher.Tag
 {
     /// <summary>
     /// タグ選択GUIの管理
@@ -184,15 +184,17 @@ namespace ToolLauncher
             return isClick;
         }
 
-
-        Texture2D GetIconTexture(string tag, Color c)
+        /// <summary>
+        /// アイコン画像の取得
+        /// </summary>
+        private Texture2D GetIconTexture(string tagName, Color c)
         {
-            if (!tagTextures.ContainsKey(tag))
+            if (!tagTextures.ContainsKey(tagName))
             {
-                tagTextures[tag] = new Texture2D(1, 1);
+                tagTextures[tagName] = new Texture2D(1, 1);
             }
             
-            var t = tagTextures[tag];
+            var t = tagTextures[tagName];
             for (int x = 0; x < t.width; x++)
             {
                 for (int y = 0; y < t.height; y++)

--- a/Editor/Tag/TagManager.cs
+++ b/Editor/Tag/TagManager.cs
@@ -12,11 +12,13 @@ namespace ToolLauncher
     public class TagManager
     {
         [NonSerialized] private Dictionary<string, bool> tagEnabled = new Dictionary<string, bool>();
-
         private Dictionary<string, Texture2D> tagTextures = new Dictionary<string, Texture2D>();
 
         static class Styles
         {
+            /// <summary>
+            /// 有効なタグのボタン
+            /// </summary>
             public static readonly GUIStyle OnTagButton = new GUIStyle(GUI.skin.button)
             {
                 margin = new RectOffset(0, 0, 3,  0),
@@ -24,7 +26,10 @@ namespace ToolLauncher
                 fixedHeight = 20,
                 alignment = TextAnchor.MiddleRight,
             };
-        
+            
+            /// <summary>
+            /// 無効なタグのボタン
+            /// </summary>
             public static readonly GUIStyle OffTagButton = new GUIStyle(GUI.skin.button)
             {
                 margin = new RectOffset(0, 0, 3,  0),
@@ -34,6 +39,9 @@ namespace ToolLauncher
             };
         }
 
+        /// <summary>
+        /// 有効化されているタグの数
+        /// </summary>
         public int ActiveTagCount
         {
             get { return tagEnabled.Count(x => x.Value == true); }
@@ -113,8 +121,6 @@ namespace ToolLauncher
                 GUILayout.Space(4);
                 EditorGUILayout.LabelField("タグ", GUILayout.Width(26));
                 
-                var defaultColor = GUI.color;
-                var defaultBgColor = GUI.backgroundColor;
                 foreach (var setting in settings)
                 {
                     var tag = setting.TagName;
@@ -122,54 +128,62 @@ namespace ToolLauncher
                     {
                         continue;
                     }
-
                     if (!tagEnabled.ContainsKey(tag))
                     {
                         tagEnabled.Add(tag, false);
                     }
                     
-                    bool isOn = tagEnabled[tag];
-                    if (!isOn)
-                    {
-                        GUI.color = new Color(1, 1, 1, 0.5f);
-                    }
-                    else
-                    {
-                        GUI.color = defaultColor;
-                    }
-
-                    var style = isOn ? Styles.OnTagButton : Styles.OffTagButton;
-                    var icon = GetIconTexture(setting.TagName, setting.TagColor);
-                    GUIContent content = new GUIContent(tag);
-                    Vector2 contentSize = style.CalcSize(content);
-                    contentSize.x += 10;
-                    
-                    var controlRect = EditorGUILayout.GetControlRect(
-                        false, contentSize.y, style, 
-                        new GUILayoutOption[] { 
-                            GUILayout.Width(contentSize.x), 
-                            GUILayout.Height(contentSize.y)
-                        });
-                    
-                    bool isClick = GUI.Button(controlRect, content, style);
-                    var iconRect = new Rect(controlRect);
-                    const int iconSize = 6;
-                    iconRect.x = controlRect.x + iconSize;
-                    iconRect.y = controlRect.y + style.fixedHeight / 2 - iconSize / 2;
-                    iconRect.width = iconSize;
-                    iconRect.height = iconSize;
-                    GUI.DrawTexture(iconRect, icon);
+                    bool isClick = DrawTagButton(tag, setting);
                     if (isClick)
                     {
-                        tagEnabled[tag] = !isOn;
+                        tagEnabled[tag] = !tagEnabled[tag];
                     }
                 }
-
-                GUI.backgroundColor = defaultBgColor;
-                GUI.color = defaultColor;
                 GUILayout.FlexibleSpace();
             }
         }
+
+        /// <summary>
+        /// タグボタンの描画
+        /// </summary>
+        /// <param name="tag">タグ名</param>
+        /// <param name="setting">設定ファイル</param>
+        /// <returns>クリックされたらtrue</returns>
+        private bool DrawTagButton(string tag, ToolLauncherSetting setting)
+        {
+            const int iconSpace = 10;
+            const int iconSize = 6;
+
+            var defaultColor = GUI.color;
+            bool isOn = tagEnabled[tag];
+            if (!isOn)
+            {
+                GUI.color = new Color(1, 1, 1, 0.5f);
+            }
+
+            // ボタン
+            var buttonStyle = isOn ? Styles.OnTagButton : Styles.OffTagButton;
+            GUIContent content = new GUIContent(tag);
+            Vector2 contentSize = buttonStyle.CalcSize(content);
+            contentSize.x += iconSpace; // アイコン用に幅を広げる
+            var controlRect = EditorGUILayout.GetControlRect(false, contentSize.y, buttonStyle, GUILayout.Width(contentSize.x)); 
+            bool isClick = GUI.Button(controlRect, content, buttonStyle);
+            
+            // ボタンの中のアイコン
+            var icon = GetIconTexture(setting.TagName, setting.TagColor);
+            var iconRect = new Rect(controlRect);
+            iconRect.x = controlRect.x + iconSize;
+            iconRect.y = controlRect.y + buttonStyle.fixedHeight / 2 - iconSize / 2;
+            iconRect.width = iconSize;
+            iconRect.height = iconSize;
+            GUI.DrawTexture(iconRect, icon);
+
+            // 色を元に戻す
+            GUI.color = defaultColor; 
+
+            return isClick;
+        }
+
 
         Texture2D GetIconTexture(string tag, Color c)
         {

--- a/Editor/Tag/TagManager.cs
+++ b/Editor/Tag/TagManager.cs
@@ -186,22 +186,22 @@ namespace ToolLauncher.Tag
 
             // ボタン
             var buttonStyle = isOn ? Styles.OnTagButton : Styles.OffTagButton;
-            GUIContent content = new GUIContent(tag);
-            Vector2 contentSize = buttonStyle.CalcSize(content);
-            contentSize.x += iconSpace; // アイコン用に幅を広げる
-            var controlRect = EditorGUILayout.GetControlRect(false, contentSize.y, buttonStyle, GUILayout.Width(contentSize.x)); 
-            bool isClick = GUI.Button(controlRect, content, buttonStyle);
+            GUIContent buttonContent = new GUIContent(tag);
+            Vector2 buttonContentSize = buttonStyle.CalcSize(buttonContent);
+            buttonContentSize.x += iconSpace; // アイコン用に幅を広げる
+            var buttonRect = EditorGUILayout.GetControlRect(false, buttonContentSize.y, buttonStyle, GUILayout.Width(buttonContentSize.x)); 
+            bool isClick = GUI.Button(buttonRect, buttonContent, buttonStyle);
             
             // ボタンの中のアイコン
-            var icon = GetIconTexture(setting.TagName, setting.TagColor);
-            var iconRect = new Rect(controlRect)
+            var iconTexture = GetIconTexture(setting.TagName, setting.TagColor);
+            var iconRect = new Rect(buttonRect)
             {
-                x = controlRect.x + iconSize,
-                y = controlRect.y + buttonStyle.fixedHeight / 2 - iconSize / 2,
+                x = buttonRect.x + iconSize,
+                y = buttonRect.y + buttonStyle.fixedHeight / 2 - iconSize / 2,
                 width = iconSize,
                 height = iconSize
             };
-            GUI.DrawTexture(iconRect, icon);
+            GUI.DrawTexture(iconRect, iconTexture);
 
             // 色を元に戻す
             GUI.color = defaultColor; 

--- a/Editor/Tag/TagManager.cs.meta
+++ b/Editor/Tag/TagManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ebce5e20f95742318a87faecee7d3967
+timeCreated: 1702092414

--- a/Editor/ToolLauncherSetting.cs
+++ b/Editor/ToolLauncherSetting.cs
@@ -27,9 +27,14 @@ namespace ToolLauncher
 
         [SerializeField] private string _settingName;
 
+        [SerializeField] private string _tagName;
+        [SerializeField] private Color _tagColor = new Color(1, 1 ,1 ,1);
+
         [SerializeField] protected List<ToolLauncherMenu> MenuList = new List<ToolLauncherMenu>();
 
         public string DisplayName => !string.IsNullOrEmpty(_settingName) ? _settingName : name;
+        public string TagName => _tagName;
+        public Color TagColor => _tagColor;
 
         public IReadOnlyList<ToolLauncherMenu> GetMenuList()
         {
@@ -43,11 +48,15 @@ namespace ToolLauncher
     class ToolLauncherSettingDrawer : Editor
     {
         private SerializedProperty _propSettingName;
+        private SerializedProperty _propTagName;
+        private SerializedProperty _propTagColor;
         private SerializedProperty _propMenuList;
 
         private void OnEnable()
         {
             _propSettingName = serializedObject.FindProperty("_settingName");
+            _propTagName = serializedObject.FindProperty("_tagName");
+            _propTagColor = serializedObject.FindProperty("_tagColor");
             _propMenuList = serializedObject.FindProperty("MenuList");
         }
 
@@ -55,6 +64,8 @@ namespace ToolLauncher
         {
             serializedObject.Update();
             EditorGUILayout.PropertyField(_propSettingName, new GUIContent("表示名"));
+            EditorGUILayout.PropertyField(_propTagName, new GUIContent("タグ名(省略可)"));
+            EditorGUILayout.PropertyField(_propTagColor, new GUIContent("タグカラー(省略可)"));
             EditorGUILayout.PropertyField(_propMenuList, new GUIContent("ツール一覧"));
             serializedObject.ApplyModifiedProperties();
         }

--- a/Editor/ToolLauncherSetting.cs
+++ b/Editor/ToolLauncherSetting.cs
@@ -26,14 +26,13 @@ namespace ToolLauncher
         }
 
         [SerializeField] private string _settingName;
-
         [SerializeField] private string _tagName;
         [SerializeField] private Color _tagColor = new Color(1, 1 ,1 ,1);
 
         [SerializeField] protected List<ToolLauncherMenu> MenuList = new List<ToolLauncherMenu>();
 
         public string DisplayName => !string.IsNullOrEmpty(_settingName) ? _settingName : name;
-        public string TagName => _tagName;
+        public string TagName => !string.IsNullOrEmpty(_tagName) ? _tagName : DisplayName;
         public Color TagColor => _tagColor;
 
         public IReadOnlyList<ToolLauncherMenu> GetMenuList()
@@ -64,7 +63,7 @@ namespace ToolLauncher
         {
             serializedObject.Update();
             EditorGUILayout.PropertyField(_propSettingName, new GUIContent("表示名"));
-            EditorGUILayout.PropertyField(_propTagName, new GUIContent("タグ名(省略可)"));
+            EditorGUILayout.PropertyField(_propTagName, new GUIContent("タグ名"));
             EditorGUILayout.PropertyField(_propTagColor, new GUIContent("タグカラー(省略可)"));
             EditorGUILayout.PropertyField(_propMenuList, new GUIContent("ツール一覧"));
             serializedObject.ApplyModifiedProperties();

--- a/Editor/ToolLauncherSetting.cs
+++ b/Editor/ToolLauncherSetting.cs
@@ -64,7 +64,7 @@ namespace ToolLauncher
             serializedObject.Update();
             EditorGUILayout.PropertyField(_propSettingName, new GUIContent("表示名"));
             EditorGUILayout.PropertyField(_propTagName, new GUIContent("タグ名"));
-            EditorGUILayout.PropertyField(_propTagColor, new GUIContent("タグカラー(省略可)"));
+            EditorGUILayout.PropertyField(_propTagColor, new GUIContent("タグカラー"));
             EditorGUILayout.PropertyField(_propMenuList, new GUIContent("ツール一覧"));
             serializedObject.ApplyModifiedProperties();
         }

--- a/Editor/ToolLauncherWindow.cs
+++ b/Editor/ToolLauncherWindow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ToolLauncher.ListDrawer;
 using ToolLauncher.ToolLauncherSettings;
+using ToolLauncher.Tag;
 using UnityEditor;
 using UnityEngine;
 
@@ -151,6 +152,8 @@ namespace ToolLauncher
                             data =>
                             {
                                 _setting = (ToolLauncherSetting)data;
+                                
+                                // 設定に対応するタグを有効化し、他のタグは無効化する
                                 m_TagManager.SelectTag(_setting.TagName);
                             }, s);
                     }

--- a/Editor/ToolLauncherWindow.cs
+++ b/Editor/ToolLauncherWindow.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using ToolLauncher.ListDrawer;
 using ToolLauncher.ToolLauncherSettings;
@@ -11,8 +13,9 @@ namespace ToolLauncher
         private Vector2 _scrollPosition;
 
         [SerializeField] private ToolLauncherSetting _setting;
-
         private IListDrawer _listDrawer;
+        private TagManager m_TagManager;
+        private ToolLauncherSetting[] _settings = {};
 
         [MenuItem("Window/ツールランチャー %t")]
         public static void Open()
@@ -48,6 +51,25 @@ namespace ToolLauncher
             UserSettingManager.Save(userSettings);
         }
 
+        private void OnFocus()
+        {
+            if (m_TagManager == null)
+            {
+                m_TagManager = new TagManager();
+            }
+
+            _settings = AssetDatabase
+                .FindAssets("t:" + nameof(ToolLauncherSetting))
+                .Select(x => AssetDatabase.GUIDToAssetPath(x))
+                .Select(x => AssetDatabase.LoadAssetAtPath<ToolLauncherSetting>(x))
+                .ToArray();
+
+            if (_setting != null)
+            {
+                m_TagManager.SetTagActive(_setting.TagName, true);
+            }
+        }
+
         private void OnGUI()
         {
             // 設定選択画面
@@ -60,14 +82,45 @@ namespace ToolLauncher
 
             _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
 
-            var list = _setting.GetMenuList();
-            for (var index = 0; index < list.Count; index++)
+            int index = 0;
+            
+            // タグによる描画
+            foreach (var s in _settings)
             {
-                var menu = list[index];
-                _listDrawer.Draw(new ListDrawerParam(menu, index));
+                // タグで絞り込み
+                var tagName = s.TagName;
+                if (!m_TagManager.IsTagActive(tagName))
+                {
+                    continue;
+                }
+
+                var tagColor = s.TagColor;
+                foreach (var menu in s.GetMenuList())
+                {
+                    _listDrawer.Draw(new ListDrawerParam(menu, index++, new TagData(tagName, tagColor)));
+                }
             }
 
             EditorGUILayout.EndScrollView();
+        }
+
+        private List<ToolLauncherSetting.ToolLauncherMenu> GetMenuList()
+        {
+            var list = new List<ToolLauncherSetting.ToolLauncherMenu>();             
+            foreach (var setting in _settings)
+            {
+                if (setting == null)
+                {
+                    continue;
+                }
+
+                if (m_TagManager.IsTagActive(setting.TagName))
+                {
+                    list.AddRange(setting.GetMenuList());
+                }
+            }
+
+            return list;
         }
 
         /// <summary>
@@ -77,21 +130,29 @@ namespace ToolLauncher
         {
             using (new EditorGUILayout.HorizontalScope())
             {
+                var buttonLabel = _setting != null ? _setting.DisplayName : string.Empty;
+                if (_setting != null && !string.IsNullOrEmpty(_setting.TagName) && !m_TagManager.IsOnlyActive(_setting.TagName))
+                {
+                    buttonLabel += "*";
+                }
+                
                 // 設定ファイルの選択Popup
                 // EditorGUIのPopupは表示中に設定ファイルが消えるとハンドリングできないため独自のPopup
-                var buttonContent = new GUIContent(_setting != null ? _setting.DisplayName : string.Empty);
+                var buttonContent = new GUIContent(buttonLabel);
                 var buttonRect = GUILayoutUtility.GetRect(buttonContent, EditorStyles.popup);
                 if (GUI.Button(buttonRect, buttonContent, EditorStyles.popup))
                 {
                     GenericMenu menu = new GenericMenu();
                     // 設定を持っているScriptableObjectを探す
-                    foreach (var s in AssetDatabase
-                                 .FindAssets("t:" + nameof(ToolLauncherSetting))
-                                 .Select(x => AssetDatabase.GUIDToAssetPath(x))
-                                 .Select(x => AssetDatabase.LoadAssetAtPath<ToolLauncherSetting>(x)))
+                    foreach (var s in _settings)
                     {
-                        menu.AddItem(new GUIContent(s.DisplayName), _setting == s,
-                            data => _setting = (ToolLauncherSetting)data, s);
+                        menu.AddItem(new GUIContent(s.DisplayName), 
+                            _setting == s,
+                            data =>
+                            {
+                                _setting = (ToolLauncherSetting)data;
+                                m_TagManager.SelectTag(_setting.TagName);
+                            }, s);
                     }
 
                     menu.DropDown(buttonRect);
@@ -117,6 +178,8 @@ namespace ToolLauncher
                     ShowNotification(new GUIContent($"新規作成完了"), 3f);
                 }
             }
+            
+            m_TagManager?.OnGUI(_settings);
         }
     }
 }


### PR DESCRIPTION
## 概要
ツールランチャー上で管理するツールが増えてくると、目的のツールを探すのが大変になってきます。
そこで、ツールにタグの情報を付与し、
タグでツールを絞り込めるようにする機能を追加してみました。
<img src = "https://github.com/QualiArts/UnityToolLauncher/assets/3509158/f530d011-e60b-40e4-8878-ec6996d9fffb" width = 300>

## タグの追加場所
Tool Launcher Settings 上にて、タグの名前とタグの色を指定します。

![image](https://github.com/QualiArts/UnityToolLauncher/assets/3509158/e2fb786f-f904-4c15-a843-4c28b2c4cac7)


## 環境
動作確認したUnityバージョン
- Unity2020.3.32f1
- Unity2022.3.13f1

## インストール方法
PackageManagerに以下を入力し、インストールします。
```
https://github.com/rngtm/UnityToolLauncher.git#feat/add-tag
```

![image](https://github.com/QualiArts/UnityToolLauncher/assets/3509158/e86a1ac6-31c5-4abd-962f-304cf772d765)
