### PR TITLE
GetMethod()でAmbiguousMatchExceptionが出てしまう問題を修正

### DIFF
--- a/Editor/SerializedMethodInfo.cs
+++ b/Editor/SerializedMethodInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using UnityEditor;
@@ -19,7 +20,9 @@ namespace ToolLauncher
             {
                 var type = Type.GetType(_assemblyQualifiedName);
                 if (type == null) return null;
-                return type.GetMethod(_methodName, BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+                var method = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)
+                    .First(m => m.Name == _methodName);
+                return method;
             }
         }
 


### PR DESCRIPTION
## 概要

#6 の修正提案PRとなります。

## 確認環境

Unity2023.2.3f1

## 対応内容

GetMethod()でAmbiguousMatchExceptionが出てしまう問題を修正( [785f101](https://github.com/QualiArts/UnityToolLauncher/commit/785f1018118e72393091fdf482e46b4676fdf4a6) )